### PR TITLE
Modify http to https on href

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       </dt>
       <dd>
         <a href=
-        "http://webscreens.github.io/cg-charter/">https://webscreens.github.io/cg-charter/</a>
+        "https://webscreens.github.io/cg-charter/">https://webscreens.github.io/cg-charter/</a>
       </dd>
       <dt>
         Start Date:


### PR DESCRIPTION
It had mismatch typo in link.
This Charter:
https://webscreens.github.io/cg-charter/
It was modified like below.
href="http:// -> href="https://
