### PR TITLE
Update charter proposal to specifically mention audio.

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,9 +178,10 @@
       <li>Protocols that implement all of the interfaces, attributes, methods,
       algorithms, and implementation requirements of the Remote Playback API
       are also in scope, for the specific case of remotely playing a
-      <code>&lt;video&gt;</code> element with a <code>src</code> or
-      <code>source</code>s URL media source on a presentation display. (In the
-      Remote Playback API, this is referred to as the "media flinging" case.)
+      <code>&lt;video&gt;</code> or <code>&lt;audio&gt;</code> element with a
+      <code>src</code> or <code>source</code>s URL media source on a presentation
+      display. (In the Remote Playback API, this is referred to as the 
+      media flinging" case.)
       </li>
       <li>Extension points for protocols developed are in scope, to make it
       possible to add new features via future specifications produced outside


### PR DESCRIPTION
Addresses Issue #15: Include `<audio>` in protocol for Remote Playback API

Specifically mention `<audio>` as well as `<video>` as in scope for the Remote Playback API.
